### PR TITLE
Add coverage commands and use shell isolation for github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,15 @@ jobs:
         env:
           - ROS_DISTRO: foxy
             ROS_REPO: main
-            DOCKER_IMAGE: "tanjpg/easy_manipulation_deployment:ci"
             AFTER_INIT_EMBED: "ici_source_setup /opt/moveit2/install"
+            TARGET_CMAKE_ARGS: "-DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'"
+            AFTER_SCRIPT: "./coverage.sh ci"
+            ISOLATION: "shell" 
     env:
-      CCACHE_DIR: ${{ github.workspace }}/.ccache
-    runs-on: ubuntu-latest
+      CCACHE_DIR: /github/home/.ccache 
+    runs-on: ubuntu-20.04
+    container:
+      image: docker://tanjpg/easy_manipulation_deployment:ci
     steps:
       - uses: actions/checkout@v2
       # step up caching
@@ -26,4 +30,5 @@ jobs:
         env: ${{matrix.env}}
       - uses: codecov/codecov-action@v1
         with:
+          files: ./coverage.info
           fail_ci_if_error: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,3 @@
-# Build only merge request and default branch.
-# save time for quick demo pushes
-include:
-  - template: 'Workflows/MergeRequest-Pipelines.gitlab-ci.yml'
-
 # Build with moveit
 foxy-moveit2:
   image:
@@ -20,12 +15,14 @@ foxy-moveit2:
     ISOLATION: "shell"
     ROS_DISTRO: "foxy"
     CCACHE_DIR: "${CI_PROJECT_DIR}/.ccache"
+    TARGET_CMAKE_ARGS: "-DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'"
 
   script:
     - .industrial_ci/gitlab.sh
-  
-  # after_script:
-  #   - bash <(curl -s https://codecov.io/bash)
+
+  after_script:
+    - ./coverage.sh ci
+    - bash <(curl -s https://codecov.io/bash) -f ./coverage.info
 
 # Build Documentation
 sphinx-docs:
@@ -75,7 +72,7 @@ doxygen-docs:
 
   script:
     - (cd docs/doxygen && doxygen)
-  
+
   artifacts:
     paths:
       - docs/doxygen/html/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,8 @@
+# Build only merge request and default branch.
+# save time for quick demo pushes
+include:
+  - template: 'Workflows/MergeRequest-Pipelines.gitlab-ci.yml'
+
 # Build with moveit
 foxy-moveit2:
   image:

--- a/coverage.sh
+++ b/coverage.sh
@@ -4,8 +4,18 @@
 # Then run ./src/easy_manipulation_deployment/coverage.sh html
 # Coverage report will be generate automatically
 
+# Enable branch coverage for local report
+# ./src/easy_manipulation_deployment/coverage.sh html
+
 if [ "$1" = "ci" ]; then
-  cd ~/target_ws
+  cd ~/target_ws || return 1
+fi
+
+branch_command=()
+branch_html_command=()
+if [ "$2" = "--branch" ]; then
+  branch_command=(--rc "lcov_branch_coverage=1")
+  branch_html_command=(--branch-coverage)
 fi
 
 package_name="easy_manipulation_deployment"
@@ -13,8 +23,7 @@ package_name="easy_manipulation_deployment"
 ignored_files="*/test/*"
 
 # Install LCOV
-
-if [ $(dpkg-query -W -f='${Status}' lcov 2>/dev/null | grep -c "ok installed") -eq 0 ];
+if [ "$(dpkg-query -W -f='${Status}' lcov 2>/dev/null | grep -c 'ok installed')" -eq 0 ];
 then
   sudo apt-get install -y -qq lcov
 fi
@@ -23,30 +32,30 @@ fi
 # Capture initial coverage info
 lcov --capture --initial \
      --directory build \
-     --output-file initial_coverage.info | grep -ve "^Processing"
+     --output-file initial_coverage.info "${branch_command[@]}" | grep -ve "^Processing"
 # Capture tested coverage info
 lcov --capture \
      --directory build \
-     --output-file test_coverage.info | grep -ve "^Processing"
+     --output-file test_coverage.info "${branch_command[@]}" | grep -ve "^Processing"
 # Combine two report (exit function  when none of the records are valid)
 lcov --add-tracefile initial_coverage.info \
      --add-tracefile test_coverage.info \
-     --output-file coverage.info || return 0 \
+     --output-file coverage.info "${branch_command[@]}" || return 0 \
   && rm initial_coverage.info test_coverage.info
 # Extract repository files
 lcov --extract coverage.info "$(pwd)/src/$package_name/*" \
-     --output-file coverage.info | grep -ve "^Extracting"
+     --output-file coverage.info "${branch_command[@]}" | grep -ve "^Extracting"
 # Filter out ignored files
 lcov --remove coverage.info "$ignored_files" \
-     --output-file coverage.info | grep -ve "^removing"
+     --output-file coverage.info "${branch_command[@]}" | grep -ve "^removing"
 if [ "$1" = "ci" ]; then
   # Some sed magic to remove identifiable absolute path
   sed -i "s~$(pwd)/src/$package_name/~~g" coverage.info
-  lcov --list coverage.info
+  lcov --list coverage.info "${branch_command[@]}"
 
-  cd -
+  cd - || return 1
   cp -r ~/target_ws/coverage.info .
 
 elif [ "$1" = "html" ]; then
-  genhtml coverage.info -o coverage
+  genhtml "${branch_html_command[@]}" coverage.info -o coverage
 fi

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# To use this locally, go to the root of your workspace
+# cd ~/<workspace-name>/
+# Then run ./src/easy_manipulation_deployment/coverage.sh html
+# Coverage report will be generate automatically
+
+if [ "$1" = "ci" ]; then
+  cd ~/target_ws
+fi
+
+package_name="easy_manipulation_deployment"
+
+ignored_files="*/test/*"
+
+# Install LCOV
+
+if [ $(dpkg-query -W -f='${Status}' lcov 2>/dev/null | grep -c "ok installed") -eq 0 ];
+then
+  sudo apt-get install -y -qq lcov
+fi
+
+
+# Capture initial coverage info
+lcov --capture --initial \
+     --directory build \
+     --output-file initial_coverage.info | grep -ve "^Processing"
+# Capture tested coverage info
+lcov --capture \
+     --directory build \
+     --output-file test_coverage.info | grep -ve "^Processing"
+# Combine two report (exit function  when none of the records are valid)
+lcov --add-tracefile initial_coverage.info \
+     --add-tracefile test_coverage.info \
+     --output-file coverage.info || return 0 \
+  && rm initial_coverage.info test_coverage.info
+# Extract repository files
+lcov --extract coverage.info "$(pwd)/src/$package_name/*" \
+     --output-file coverage.info | grep -ve "^Extracting"
+# Filter out ignored files
+lcov --remove coverage.info "$ignored_files" \
+     --output-file coverage.info | grep -ve "^removing"
+if [ "$1" = "ci" ]; then
+  # Some sed magic to remove identifiable absolute path
+  sed -i "s~$(pwd)/src/$package_name/~~g" coverage.info
+  lcov --list coverage.info
+
+  cd -
+  cp -r ~/target_ws/coverage.info .
+
+elif [ "$1" = "html" ]; then
+  genhtml coverage.info -o coverage
+fi

--- a/easy_manipulation_deployment/grasp_planner/CMakeLists.txt
+++ b/easy_manipulation_deployment/grasp_planner/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
-  set(CMAKE_CXX_FLAGS "-g -O0 -Wall -fprofile-arcs -ftest-coverage")
 endif()
 
 # add_definitions(-DEIGEN_MAX_ALIGN_BYTES=16)
@@ -156,31 +155,6 @@ if(BUILD_TESTING)
   ${GTEST_LIBRARIES}
   ${Boost_LIBRARIES}
   ccd)
-  add_custom_target(gcov
-    COMMAND mkdir -p coverage
-    COMMAND ${CMAKE_MAKE_PROGRAM} test
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  add_custom_command(TARGET gcov
-    COMMAND echo "=================== GCOV ===================="
-    COMMAND gcov -b -i ${CMAKE_SOURCE_DIR}/*.cpp -o ${OBJECT_DIR}
-        | grep -A 5 "src/grasp_scene.cpp" > CoverageSummary.tmp
-    COMMAND cat CoverageSummary.tmp
-    COMMAND echo "-- Coverage files have been output to ${CMAKE_BINARY_DIR}/coverage"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/coverage)
-  add_dependencies(gcov grasp_planning_interface)
-  # Make sure to clean up the coverage folder
-  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)
-
-  # Create the gcov-clean target. This cleans the build as well as generated
-  # .gcda and .gcno files.
-  add_custom_target(scrub
-      COMMAND ${CMAKE_MAKE_PROGRAM} clean
-      COMMAND rm -f ${OBJECT_DIR}/*.gcno
-      COMMAND rm -f ${OBJECT_DIR}/*.gcda
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-  # Testing
-  enable_testing()
 
   ament_export_dependencies(rosidl_default_runtime)
 endif()


### PR DESCRIPTION
Signed-off-by: Chen Bainian <chenbn@artc.a-star.edu.sg>

Key changes in this pull request
- Use shell isolation for Github Action
- Fix coverage generation commands in CI
- Add local coverage generation capability

To generate coverage on a local PC
```bash
cd ~/<workspace-name>/
colcon build --cmake-args -DCMAKE_C_FLAGS='--coverage' -DCMAKE_CXX_FLAGS='--coverage'
colcon test --event-handlers console_direct+
./src/easy_manipulation_deployment/coverage.sh html
```
A `coverage` folder containing html would be generated.

---

Update:

Add in the `--branch` option for local generation.
```bash
./src/easy_manipulation_deployment/coverage.sh html --branch
```
