### PR TITLE
Fix pipeline: deprecated runs on and codecov update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
             ISOLATION: "shell"
             CODE_COVERAGE: "codecov.io"
     env:
-      CCACHE_DIR: ~/.ccache
+      CCACHE_DIR: /github/home/.ccache
     runs-on: ubuntu-latest
     container:
       image: ubuntu:20.04
@@ -29,7 +29,7 @@ jobs:
         env: ${{matrix.env}}
       # Upload Coverage report if configured
       - name: Install dependency for Codecov
-        run: sudo apt install curl -y
+        run: sudo apt install curl git -y
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.env.CODE_COVERAGE == 'codecov.io' }}
         uses: codecov/codecov-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
             CODE_COVERAGE: "codecov.io"
     env:
       CCACHE_DIR: ~/.ccache
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       # step up caching

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
Fix outdated pipeline
- Change runs-on to `ubuntu-latest` due to 20.04 deprecation https://github.com/actions/runner-images/issues/11101
- Add `git` as codecov upload script dependency
- Disable patch coverage checks